### PR TITLE
use default, cross-platform Gradle settings

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="LOCAL" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.2.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/.." />


### PR DESCRIPTION
This fixes strange warnings in Gradle files when the project is opened on a non-Windows machine.

See [this StackOverflow answer](http://stackoverflow.com/a/30828772/2556682) for more information.