### PR TITLE
better way to depend on DFULibrary

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -8,8 +8,6 @@
         <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.2.1" />
         <option name="modules">
           <set>
-            <option value="$PROJECT_DIR$/.." />
-            <option value="$PROJECT_DIR$/../DFULibrary" />
             <option value="$PROJECT_DIR$/../DFULibrary/dfu" />
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/../...iml" filepath="$PROJECT_DIR$/../...iml" />
-      <module fileurl="file://$PROJECT_DIR$/../DFULibrary/DFULibrary.iml" filepath="$PROJECT_DIR$/../DFULibrary/DFULibrary.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/../DFULibrary/dfu/dfu.iml" filepath="$PROJECT_DIR$/../DFULibrary/dfu/dfu.iml" />
       <module fileurl="file://$PROJECT_DIR$/nRFToolbox.iml" filepath="$PROJECT_DIR$/nRFToolbox.iml" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.2.0'
     compile 'com.android.support:design:22.2.0'
-    compile project(':..:DFULibrary:dfu')
+    compile project(':dfu')
     compile files('libs/achartengine-1.1.0.jar')
     compile files('libs/nrf-logger-v2.0.jar')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
-include ':app', '..:DFULibrary:dfu'
+include ':app'
+
+include ':dfu'
+project(':dfu').projectDir = file('../DFULibrary/dfu')


### PR DESCRIPTION
This makes a few things better, such as removing the weird `..` module and the `DFULibrary/*.gradle` files from Android Studio.

See [this StackOverflow answer](http://stackoverflow.com/a/19303545/2556682) for more information.