### PR TITLE
Gradle Plugin 3.3.0 proguard-rules fix

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,4 @@
--libraryjars ../app/libs
+-libraryjars ../app/libs/achartengine-1.2.0.jar
 -optimizationpasses 5
 -dontusemixedcaseclassnames
 -dontskipnonpubliclibraryclasses

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This fix is only necessary if you update to Gradle Plugin 3.3.0 so feel free to disregard if you are staying on 3.2.1.

The issues seems to be that Gradle Plugin 3.3.0 requires jar files to be specified in proguard files instead of directories.