### PR TITLE
Version 2.8.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'no.nordicsemi.android.support.v18:scanner:1.4.3'
 
     // The DFU Library is imported automatically from jcenter:
-    implementation 'no.nordicsemi.android:dfu:1.9.1'
+    implementation 'no.nordicsemi.android:dfu:1.10.0'
     // if you desire to build the DFU Library, clone the
     // https://github.com/NordicSemiconductor/Android-DFU-Library project into DFULibrary folder,
     // add it as a module into the project structure and uncomment the following line
@@ -60,7 +60,6 @@ dependencies {
     // Gson is needed for DFU to work. The DFU library dependency to Gson is internal and would
     // not be attached to APK.
     // See: https://github.com/NordicSemiconductor/Android-nRF-Toolbox/issues/86
-    implementation 'com.google.code.gson:gson:2.8.6'
 
     // Import the BLE Common Library.
     // The BLE Common Library depends on BLE Library. It is enough to include the first one.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "no.nordicsemi.android.nrftoolbox"
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 74
-        versionName "2.8.2"
+        versionCode 75
+        versionName "2.8.3"
         resConfigs "en"
 
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/no/nordicsemi/android/nrftoolbox/dfu/DfuActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrftoolbox/dfu/DfuActivity.java
@@ -703,6 +703,7 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 				.setForceDfu(forceDfu)
 				.setPacketsReceiptNotificationsEnabled(enablePRNs)
 				.setPacketsReceiptNotificationsValue(numberOfPackets)
+				.setPrepareDataObjectDelay(400)
 				.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
 		if (fileType == DfuService.TYPE_AUTO) {
 			starter.setZip(fileStreamUri, filePath);

--- a/app/src/main/java/no/nordicsemi/android/nrftoolbox/dfu/DfuActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrftoolbox/dfu/DfuActivity.java
@@ -539,16 +539,20 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 			if (fileType != DfuService.TYPE_AUTO) {
 				scope = null;
 				fileScopeView.setText(getString(R.string.not_available));
-				new AlertDialog.Builder(this).setTitle(R.string.dfu_file_init_title).setMessage(R.string.dfu_file_init_message)
+				new AlertDialog.Builder(this)
+						.setTitle(R.string.dfu_file_init_title)
+						.setMessage(R.string.dfu_file_init_message)
 						.setNegativeButton(R.string.no, (dialog, which) -> {
 							initFilePath = null;
 							initFileStreamUri = null;
-						}).setPositiveButton(R.string.yes, (dialog, which) -> {
+						})
+						.setPositiveButton(R.string.yes, (dialog, which) -> {
 							final Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 							intent.setType(DfuService.MIME_TYPE_OCTET_STREAM);
 							intent.addCategory(Intent.CATEGORY_OPENABLE);
 							startActivityForResult(intent, SELECT_INIT_FILE_REQ);
-						}).show();
+						})
+						.show();
 			} else {
 				new AlertDialog.Builder(this).setTitle(R.string.dfu_file_scope_title).setCancelable(false)
 						.setSingleChoiceItems(R.array.dfu_file_scope, 0, (dialog, which) -> {
@@ -584,7 +588,10 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 	 * @param view a button that was pressed
 	 */
 	public void onSelectFileHelpClicked(final View view) {
-		new AlertDialog.Builder(this).setTitle(R.string.dfu_help_title).setMessage(R.string.dfu_help_message).setPositiveButton(R.string.ok, null)
+		new AlertDialog.Builder(this)
+				.setTitle(R.string.dfu_help_title)
+				.setMessage(R.string.dfu_help_message)
+				.setPositiveButton(R.string.ok, null)
 				.show();
 	}
 
@@ -611,7 +618,8 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 				break;
 		}
 		// Show a dialog with file types
-		new AlertDialog.Builder(this).setTitle(R.string.dfu_file_type_title)
+		new AlertDialog.Builder(this)
+				.setTitle(R.string.dfu_file_type_title)
 				.setSingleChoiceItems(R.array.dfu_file_type, index, (dialog, which) -> {
 					switch (which) {
 						case 0:
@@ -627,10 +635,14 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 							fileTypeTmp = DfuService.TYPE_APPLICATION;
 							break;
 					}
-				}).setPositiveButton(R.string.ok, (dialog, which) -> openFileChooser()).setNeutralButton(R.string.dfu_file_info, (dialog, which) -> {
-			final ZipInfoFragment fragment = new ZipInfoFragment();
-			fragment.show(getSupportFragmentManager(), "help_fragment");
-		}).setNegativeButton(R.string.cancel, null).show();
+				})
+				.setPositiveButton(R.string.ok, (dialog, which) -> openFileChooser())
+				.setNeutralButton(R.string.dfu_file_info, (dialog, which) -> {
+					final ZipInfoFragment fragment = new ZipInfoFragment();
+					fragment.show(getSupportFragmentManager(), "help_fragment");
+				})
+				.setNegativeButton(R.string.cancel, null)
+				.show();
 	}
 
 	private void openFileChooser() {
@@ -647,15 +659,19 @@ public class DfuActivity extends AppCompatActivity implements LoaderCallbacks<Cu
 			appsList.setAdapter(new FileBrowserAppsAdapter(this));
 			appsList.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
 			appsList.setItemChecked(0, true);
-			new AlertDialog.Builder(this).setTitle(R.string.dfu_alert_no_filebrowser_title).setView(customView)
-					.setNegativeButton(R.string.no, (dialog, which) -> dialog.dismiss()).setPositiveButton(R.string.ok, (dialog, which) -> {
+			new AlertDialog.Builder(this)
+					.setTitle(R.string.dfu_alert_no_filebrowser_title)
+					.setView(customView)
+					.setNegativeButton(R.string.no, (dialog, which) -> dialog.dismiss())
+					.setPositiveButton(R.string.ok, (dialog, which) -> {
 						final int pos = appsList.getCheckedItemPosition();
 						if (pos >= 0) {
 							final String query = getResources().getStringArray(R.array.dfu_app_file_browser_action)[pos];
 							final Intent storeIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(query));
 							startActivity(storeIntent);
 						}
-					}).show();
+					})
+					.show();
 		}
 	}
 

--- a/app/src/main/res/values/strings_dfu.xml
+++ b/app/src/main/res/values/strings_dfu.xml
@@ -47,7 +47,8 @@
 	<string name="dfu_action_select_file">SELECT FILE</string>
 	
 	<string name="dfu_alert_no_filebrowser_title">File Browser not found</string>
-	<string name="dfu_alert_no_filebrowser_message">File browser application has not been found on your device. Would you like to download one?</string>
+	<string name="dfu_alert_no_filebrowser_message">File browser application has not been found on
+		your device. Would you like to download one?</string>
 	<string-array name="dfu_app_file_browser">
 		<item>Drive</item>
 		<item>File Manager</item>
@@ -72,15 +73,19 @@
 	<string name="dfu_settings_dfu_mbr_size_title">MBR size (by default 4096 bytes)</string>
 	<string name="dfu_settings_dfu_keep_bond">Keep bond information</string>
 	<string name="dfu_settings_dfu_assume_dfu_mode">External MCU DFU</string>
-	<string name="dfu_settings_dfu_assume_dfu_mode_info">Check this switch to ON if you want to perform a DFU operation without jumping to the bootloader mode on a device
-		with a DFU implementation from SDK 6.1 or older. To achieve the same result on any newer implementation the DFU Version characteristic should return value other than 0x0100.</string>
+	<string name="dfu_settings_dfu_assume_dfu_mode_info">Check this switch to ON if you want to
+		perform a DFU operation without jumping to the bootloader mode on a device with a DFU
+		implementation from SDK 6.1 or older. To achieve the same result on any newer implementation
+		the DFU Version characteristic should return value other than 0x0100.</string>
 	<string name="dfu_settings_dfu_about">About DFU</string>
 	<string name="dfu_settings_dfu_about_summary">DFU documentation on Nordic\'s Developer Zone</string>
 	<string name="dfu_settings_dfu_information">Information</string>
-	<string name="dfu_settings_dfu_number_of_packets_info">During a DFU operation a lot of data packets are being sent to the target. The <i>onCharacteristicWrite(...)</i>
-		callback in Android API is invoked when the data has been written to the outgoing queue, not when physically sent. Packet receipt notifications were introduced to
-		prevent from overflowing the queue. Depending on the device model, disabling the notifications or setting the value to “high” (> ~300) may make the DFU process freeze
-		at some point on Android versions before Marshmallow.</string>
+	<string name="dfu_settings_dfu_number_of_packets_info">During a DFU operation a lot of data packets
+		are being sent to the target. The <i>onCharacteristicWrite(...)</i> callback in Android API
+		is invoked when the data has been written to the outgoing queue, not when physically sent.
+		Packet receipt notifications were introduced to prevent from overflowing the queue. Depending
+		on the device model, disabling the notifications or setting the value to “high” (> ~300)
+		may make the DFU process freeze at some point on Android versions before Marshmallow.</string>
 	
 	<string name="dfu_file_type_title">Select file type</string>
 	<string-array name="dfu_file_type">
@@ -91,8 +96,9 @@
 	</string-array>
 	<string name="dfu_file_init_title">Init packet</string>
 	<string name="dfu_file_init_message">Do you want to select the Init packet file?\n
-		The Init packet file (*.dat) should contain the device type and revision, application version, list of supported Soft Devices and the firmware CRC
-		in binary format or, with old versions of the DFU bootloader, only the CRC (CRC-CCITT-16).
+		The Init packet file (*.dat) should contain the device type and revision, application version,
+		list of supported Soft Devices and the firmware CRC in binary format or, with old versions
+		of the DFU bootloader, only the CRC (CRC-CCITT-16).
 		With the new version of the bootloader the extended Init packet is <b>required</b>.</string>
 	<string name="dfu_file_scope_title">Select scope</string>
 	<string-array name="dfu_file_scope">
@@ -110,19 +116,23 @@
 	<string name="dfu_aborted">Uploading of the application has been canceled.</string>
 	
 	<string name="dfu_help_title">Select file</string>
-	<string name="dfu_help_message">A file browser application must be installed on the device before selecting the file.
-		\n\nThere are number of applications available on Google Play store, e.g. Total Commander or File Manager, that allow you to pick a file from internal memory of the device. To upload
-		a file from the Internet you may use e.g. Drive or Dropbox application.
-		\n\nYou will be asked to select an application if more than one is installed. A single application will be launched automatically.
-		\n\nSince <b>Android KitKat</b> you may use the preinstalled document picker application. Ensure <i>Display advanced devices</i> option is enabled in settings to use the <i>Internal storage</i>.
-		\n\nSample applications were copied to <i>Nordic Semiconductor</i> folder in the internal storage.</string>
+	<string name="dfu_help_message">A file browser application must be installed on the device before
+		selecting the file.\n\nThere are number of applications available on Google Play store,
+		e.g. Total Commander or File Manager, that allow you to pick a file from internal memory
+		of the device. To upload a file from the Internet you may use e.g. Drive or Dropbox application.
+		\n\nYou will be asked to select an application if more than one is installed. A single
+		application will be launched automatically.\n\nSince <b>Android KitKat</b> you may use the
+		preinstalled document picker application. Ensure <i>Show internal storage</i> option is
+		enabled in the menu to use the <i>Internal storage</i>.</string>
 	
-	<string name="dfu_zip_info_text">Starting from nRF Toolbox v1.12 the new Distribution packet (ZIP) is the recommended method for distributing firmware upgrades.
-		You can create the ZIP file using the <b>nrf utility</b> tool, which is part of Master Control Panel 3.8.0+. For more detailed information, see the DFU documentation.
+	<string name="dfu_zip_info_text">Starting from nRF Toolbox v1.12 the new Distribution packet (ZIP)
+		is the recommended method for distributing firmware upgrades. You can create the ZIP file
+		using the <b>nrf util</b> tool (see GitHub). For more detailed information, see the DFU documentation.
 		\n\n<b>Backward compatibility</b>
-		\nThe nRF Toolbox also supports all old file formats: HEX and BIN files, separate DAT files and ZIP files without a manifest file but with a fixed naming convention:
-</string>
-	<string name="dfu_about_text">The Device Firmware Update (DFU) app allows you to update the firmware of your Bluetooth LE device over-the-air (OTA).
-		It is compatible with Nordic Semiconductor nRF5 devices with DFU bootloader enabled.
+		\nThe nRF Toolbox also supports all old file formats: HEX and BIN files, separate DAT files
+		and ZIP files without a manifest file but with a fixed naming convention:</string>
+	<string name="dfu_about_text">The Device Firmware Update (DFU) app allows you to update the
+		firmware of your Bluetooth LE device over-the-air (OTA). It is compatible with Nordic
+		Semiconductor nRF5 devices with DFU bootloader enabled.
 		\n\nFor more information about the DFU, see the About DFU section in Settings.</string>
 </resources>

--- a/app/src/main/res/values/strings_dfu.xml
+++ b/app/src/main/res/values/strings_dfu.xml
@@ -24,7 +24,7 @@
 	<string name="dfu_feature_title">DFU</string>
 	<string name="dfu_service_title">nRF Toolbox DFU Proxy</string>
 	<string name="dfu_settings_title">DFU Settings</string>
-	<string name="dfu_lib_version">DFU Library version 1.9.1</string>
+	<string name="dfu_lib_version">DFU Library version 1.10.0</string>
 
 	<string name="dfu_feature_title_long">DEVICE FIRMWARE UPDATE</string>
 	<dimen name="dfu_feature_title_long_margin">-186dp</dimen>


### PR DESCRIPTION
Bugs fixed:
* DFU library 1.9.1 had missing dependency configuration in POM file on jcenter. It has been updated to 1.10.0, a version that not only fixed the issue, but also improved reliability of the DFU process by introducing delays before sending every data object. Check out DFU Library 1.10.0 for details.