### PR TITLE
Switch AlarmManager to RingtoneManager

### DIFF
--- a/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXRepository.kt
+++ b/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXRepository.kt
@@ -84,7 +84,6 @@ class PRXRepository @Inject internal constructor(
     }
 
     fun release() {
-        alarmHandler.releaseAlarm()
         manager?.disconnect()?.enqueue()
         manager = null
         logger = null


### PR DESCRIPTION
Switch AlarmManger to RingtoneManger.

The reason for the change is a mysterious crash that happens only on a few devices.

Fatal Exception: java.lang.SecurityException
no.nordicsemi.android.nrftoolbox was not granted this permission: android.permission.WRITE_SETTINGS.

- android.os.Parcel.createExceptionOrNull (Parcel.java:2385)
- android.media.MediaPlayer.setDataSource (MediaPlayer.java:1072)
- no.nordicsemi.android.prx.repository.AlarmHandler.<init> (AlarmHandler.kt:30)
- no.nordicsemi.android.nrftoolbox.DaggerNrfToolboxApplication_HiltComponents_SingletonC.alarmHandler (DaggerNrfToolboxApplication_HiltComponents_SingletonC.java:185)
- no.nordicsemi.android.nrftoolbox.DaggerNrfToolboxApplication_HiltComponents_SingletonC.access$4400 (DaggerNrfToolboxApplication_HiltComponents_SingletonC.java:115)  