### PR TITLE
Fix crash when LinkLoss occurs before establishing successful connection

### DIFF
--- a/lib_service/src/main/java/no/nordicsemi/android/service/BleManagerStatus.kt
+++ b/lib_service/src/main/java/no/nordicsemi/android/service/BleManagerStatus.kt
@@ -29,7 +29,7 @@ class IdleResult<T> : BleManagerResult<T>
 class ConnectingResult<T>(device: BluetoothDevice) : DeviceHolder(device), BleManagerResult<T>
 class SuccessResult<T>(device: BluetoothDevice, val data: T) : DeviceHolder(device), BleManagerResult<T>
 
-class LinkLossResult<T>(device: BluetoothDevice, val data: T) : DeviceHolder(device), BleManagerResult<T>
+class LinkLossResult<T>(device: BluetoothDevice, val data: T?) : DeviceHolder(device), BleManagerResult<T>
 class DisconnectedResult<T>(device: BluetoothDevice) : DeviceHolder(device), BleManagerResult<T>
 class UnknownErrorResult<T>(device: BluetoothDevice) : DeviceHolder(device), BleManagerResult<T>
 class MissingServiceResult<T>(device: BluetoothDevice) : DeviceHolder(device), BleManagerResult<T>

--- a/lib_service/src/main/java/no/nordicsemi/android/service/ConnectionObserverAdapter.kt
+++ b/lib_service/src/main/java/no/nordicsemi/android/service/ConnectionObserverAdapter.kt
@@ -46,7 +46,7 @@ class ConnectionObserverAdapter<T> : ConnectionObserver {
         Log.d(TAG, "onDeviceDisconnected(), reason: $reason")
         _status.value = when (reason) {
             ConnectionObserver.REASON_NOT_SUPPORTED -> MissingServiceResult(device)
-            ConnectionObserver.REASON_LINK_LOSS -> LinkLossResult(device, getData()!!)
+            ConnectionObserver.REASON_LINK_LOSS -> LinkLossResult(device, getData())
             ConnectionObserver.REASON_SUCCESS -> DisconnectedResult(device)
             else -> UnknownErrorResult(device)
         }

--- a/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXRepository.kt
+++ b/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXRepository.kt
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.prx.repository
 
-import android.bluetooth.BluetoothDevice
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -68,7 +67,8 @@ class PRXRepository @Inject internal constructor(
             }
         }
         (result as? LinkLossResult<PRXData>)?.let {
-            alarmHandler.playAlarm(it.data.linkLossAlarmLevel)
+            val alarmLevel = it.data?.linkLossAlarmLevel ?: AlarmLevel.HIGH
+            alarmHandler.playAlarm(alarmLevel)
         }
     }
 


### PR DESCRIPTION
Fix crash when LinkLoss occurs before establishing a successful connection

Fatal Exception: java.lang.NullPointerException 
no.nordicsemi.android.service.ConnectionObserverAdapter.onDeviceDisconnected (ConnectionObserverAdapter.kt:49)
no.nordicsemi.android.ble.BleManagerHandler.lambda$notifyDeviceDisconnected$88 (BleManagerHandler.java:1619)
no.nordicsemi.android.ble.BleManagerHandler$$InternalSyntheticLambda$1$9f66cb2f834f9b58429a9688872345d550f852c7c2b06c1d057e5009ebd97abd$2.run$bridge (BleManagerHandler.java:5)
no.nordicsemi.android.ble.BleManagerHandler.lambda$postConnectionStateChange$79 (BleManagerHandler.java:1385)
no.nordicsemi.android.ble.BleManagerHandler$3$$InternalSyntheticLambda$0$8d19e6ce89fe9f2131286e70e9cf3a0cbc09693786214531c3c4ed467ff11a14$9.run$bridge (BleManagerHandler.java:1) 