### PR TITLE
Migration to latest BLEK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
     alias(libs.plugins.nordic.hilt)
 }
 
-if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release")){
+if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release")) {
     apply(plugin = "com.google.gms.google-services")
     apply(plugin = "com.google.firebase.crashlytics")
 }
@@ -69,18 +69,14 @@ dependencies {
     implementation(libs.nordic.uilogger)
     implementation(libs.nordic.permissions.ble)
     implementation(libs.nordic.analytics)
+    
+    implementation(libs.nordic.blek.client)
 
-    implementation(libs.androidx.lifecycle.runtime.compose)
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-
-    implementation(libs.androidx.hilt.navigation.compose)
-
-    implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 
-    implementation(libs.nordic.blek.client)
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/lib_scanner/build.gradle.kts
+++ b/lib_scanner/build.gradle.kts
@@ -39,12 +39,12 @@ android {
 
 dependencies {
     implementation(libs.nordic.navigation)
-    implementation(libs.nordic.blek.uiscanner)
 
+    implementation(libs.nordic.blek.uiscanner)
     implementation(libs.nordic.blek.scanner)
 
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
 }

--- a/lib_service/build.gradle.kts
+++ b/lib_service/build.gradle.kts
@@ -40,11 +40,8 @@ android {
 
 dependencies {
     implementation(project(":lib_ui"))
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
+    
     implementation(libs.nordic.blek.uiscanner)
-
     implementation(libs.nordic.blek.core)
 
     implementation(libs.androidx.lifecycle.service)

--- a/lib_service/src/main/java/no/nordicsemi/android/service/NotificationService.kt
+++ b/lib_service/src/main/java/no/nordicsemi/android/service/NotificationService.kt
@@ -38,7 +38,6 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
@@ -66,7 +65,7 @@ abstract class NotificationService : LifecycleService() {
     private fun startForegroundService() {
         // when the activity closes we need to show the notification that user is connected to the peripheral sensor
         // We start the service as a foreground service as Android 8.0 (Oreo) onwards kills any running background services
-        val notification = createNotification(R.string.csc_notification_connected_message, 0)
+        val notification = createNotification(R.string.csc_notification_connected_message)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             startForeground(NOTIFICATION_ID, notification)
         } else {
@@ -93,9 +92,8 @@ abstract class NotificationService : LifecycleService() {
      *
      * @param messageResId the message resource id. The message must have one String parameter,<br></br>
      * f.e. `<string name="name">%s is connected</string>`
-     * @param defaults
      */
-    private fun createNotification(messageResId: Int, defaults: Int): Notification {
+    private fun createNotification(messageResId: Int): Notification {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createNotificationChannel(CHANNEL_ID)
         }
@@ -112,6 +110,7 @@ abstract class NotificationService : LifecycleService() {
             .build()
     }
 
+    @Suppress("SameParameterValue")
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createNotificationChannel(channelName: String) {
         val channel = NotificationChannel(

--- a/lib_service/src/main/java/no/nordicsemi/android/service/NotificationService.kt
+++ b/lib_service/src/main/java/no/nordicsemi/android/service/NotificationService.kt
@@ -38,6 +38,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
@@ -81,7 +82,7 @@ abstract class NotificationService : LifecycleService() {
         // when the activity rebinds to the service, remove the notification and stop the foreground service
         // on devices running Android 8.0 (Oreo) or above
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            stopForeground(true)
+            stopForeground(STOP_FOREGROUND_REMOVE)
         } else {
             cancelNotification()
         }

--- a/lib_ui/build.gradle.kts
+++ b/lib_ui/build.gradle.kts
@@ -43,13 +43,13 @@ android {
 
 dependencies {
     implementation(libs.nordic.uilogger)
-
     implementation(libs.nordic.theme)
+    implementation(libs.nordic.logger)
 
+    implementation(libs.nordic.blek.client)
+
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.nordic.blek.client)
-    implementation(libs.nordic.logger)
 }

--- a/lib_utils/build.gradle.kts
+++ b/lib_utils/build.gradle.kts
@@ -40,6 +40,8 @@ android {
 
 dependencies {
     implementation(libs.nordic.navigation)
+
     implementation(libs.nordic.blek.uiscanner)
+
     implementation(libs.kotlinx.coroutines.core)
 }

--- a/profile_bps/build.gradle.kts
+++ b/profile_bps/build.gradle.kts
@@ -47,19 +47,17 @@ dependencies {
 
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
+    implementation(libs.nordic.blek.uiscanner)
 
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.theme)
     implementation(libs.nordic.uilogger)
 
-    implementation(libs.nordic.blek.uiscanner)
-
-    implementation(libs.androidx.compose.material.iconsExtended)
-    implementation(libs.androidx.hilt.navigation.compose)
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.iconsExtended)
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_bps/src/main/java/no/nordicsemi/android/bps/viewmodel/BPSViewModel.kt
+++ b/profile_bps/src/main/java/no/nordicsemi/android/bps/viewmodel/BPSViewModel.kt
@@ -127,7 +127,7 @@ internal class BPSViewModel @Inject constructor(
 
         logger = DefaultBleLogger.create(context, stringConst.APP_NAME, "BPS", device.address)
 
-        val client = ClientBleGatt.connect(context, device, logger = logger)
+        val client = ClientBleGatt.connect(context, device, viewModelScope, logger = logger)
         this@BPSViewModel.client = client
 
         client.connectionStateWithStatus

--- a/profile_cgms/build.gradle.kts
+++ b/profile_cgms/build.gradle.kts
@@ -45,22 +45,20 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
+    implementation(libs.nordic.uilogger)
+    implementation(libs.nordic.navigation)
+
+    implementation(libs.nordic.blek.uiscanner)
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
 
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-    implementation(libs.nordic.uilogger)
-
-    implementation(libs.nordic.theme)
-    implementation(libs.nordic.blek.uiscanner)
-    implementation(libs.nordic.navigation)
-    implementation(libs.nordic.core)
-
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_cgms/src/main/java/no/nordicsemi/android/cgms/repository/CGMService.kt
+++ b/profile_cgms/src/main/java/no/nordicsemi/android/cgms/repository/CGMService.kt
@@ -45,12 +45,12 @@ import kotlinx.coroutines.launch
 import no.nordicsemi.android.cgms.data.CGMRecordWithSequenceNumber
 import no.nordicsemi.android.cgms.data.CGMServiceCommand
 import no.nordicsemi.android.kotlin.ble.client.main.callback.ClientBleGatt
-import no.nordicsemi.android.kotlin.ble.client.main.errors.GattOperationException
 import no.nordicsemi.android.kotlin.ble.client.main.service.ClientBleGattCharacteristic
 import no.nordicsemi.android.kotlin.ble.client.main.service.ClientBleGattServices
 import no.nordicsemi.android.kotlin.ble.core.ServerDevice
 import no.nordicsemi.android.kotlin.ble.core.data.GattConnectionState
 import no.nordicsemi.android.kotlin.ble.core.data.GattConnectionStateWithStatus
+import no.nordicsemi.android.kotlin.ble.core.errors.GattOperationException
 import no.nordicsemi.android.kotlin.ble.profile.battery.BatteryLevelParser
 import no.nordicsemi.android.kotlin.ble.profile.cgm.CGMFeatureParser
 import no.nordicsemi.android.kotlin.ble.profile.cgm.CGMMeasurementParser
@@ -58,7 +58,6 @@ import no.nordicsemi.android.kotlin.ble.profile.cgm.CGMSpecificOpsControlPointPa
 import no.nordicsemi.android.kotlin.ble.profile.cgm.CGMStatusParser
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMErrorCode
 import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMOpCode
-import no.nordicsemi.android.kotlin.ble.profile.cgm.data.CGMSpecificOpsControlPointData
 import no.nordicsemi.android.kotlin.ble.profile.gls.CGMSpecificOpsControlPointDataParser
 import no.nordicsemi.android.kotlin.ble.profile.gls.RecordAccessControlPointInputParser
 import no.nordicsemi.android.kotlin.ble.profile.gls.RecordAccessControlPointParser
@@ -133,7 +132,7 @@ internal class CGMService : NotificationService() {
     }
 
     private fun startGattClient(device: ServerDevice) = lifecycleScope.launch {
-        val client = ClientBleGatt.connect(this@CGMService, device, logger = { p, s -> repository.log(p, s) })
+        val client = ClientBleGatt.connect(this@CGMService, device, lifecycleScope, logger = { p, s -> repository.log(p, s) })
         this@CGMService.client = client
 
         client.connectionStateWithStatus

--- a/profile_csc/build.gradle.kts
+++ b/profile_csc/build.gradle.kts
@@ -45,22 +45,20 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
+    implementation(libs.nordic.uilogger)
+    implementation(libs.nordic.navigation)
+
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-    implementation(libs.nordic.uilogger)
-
-    implementation(libs.nordic.theme)
-    implementation(libs.nordic.navigation)
     implementation(libs.nordic.blek.uiscanner)
-    implementation(libs.nordic.core)
 
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_csc/src/main/java/no/nordicsemi/android/csc/repository/CSCService.kt
+++ b/profile_csc/src/main/java/no/nordicsemi/android/csc/repository/CSCService.kt
@@ -86,7 +86,7 @@ internal class CSCService : NotificationService() {
     }
 
     private fun startGattClient(device: ServerDevice) = lifecycleScope.launch {
-        val client = ClientBleGatt.connect(this@CSCService, device, logger = { p, s -> repository.log(p, s) })
+        val client = ClientBleGatt.connect(this@CSCService, device, lifecycleScope, logger = { p, s -> repository.log(p, s) })
         this@CSCService.client = client
 
         client.connectionStateWithStatus

--- a/profile_gls/build.gradle.kts
+++ b/profile_gls/build.gradle.kts
@@ -45,26 +45,25 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
+    implementation(libs.nordic.theme)
+    implementation(libs.nordic.navigation)
+    implementation(libs.nordic.uilogger)
+
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
     implementation(libs.nordic.blek.server)
     implementation(libs.nordic.blek.advertiser)
+    implementation(libs.nordic.blek.uiscanner)
 
     implementation(libs.chart)
 
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-    implementation(libs.nordic.theme)
-    implementation(libs.nordic.blek.uiscanner)
-    implementation(libs.nordic.navigation)
-    implementation(libs.nordic.uilogger)
-
-    implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 
     testImplementation(libs.hilt.android.testing)
     kaptTest(libs.hilt.compiler)

--- a/profile_gls/src/main/java/no/nordicsemi/android/gls/GlsServer.kt
+++ b/profile_gls/src/main/java/no/nordicsemi/android/gls/GlsServer.kt
@@ -44,12 +44,12 @@ class GlsServer @Inject constructor(
     private val logger: BleLogger = DefaultConsoleLogger(context)
 ) {
 
-    lateinit var server: ServerBleGatt
+    private lateinit var server: ServerBleGatt
 
-    lateinit var glsCharacteristic: ServerBleGattCharacteristic
-    lateinit var glsContextCharacteristic: ServerBleGattCharacteristic
-    lateinit var racpCharacteristic: ServerBleGattCharacteristic
-    lateinit var batteryLevelCharacteristic: ServerBleGattCharacteristic
+    private lateinit var glsCharacteristic: ServerBleGattCharacteristic
+    private lateinit var glsContextCharacteristic: ServerBleGattCharacteristic
+    private lateinit var racpCharacteristic: ServerBleGattCharacteristic
+    private lateinit var batteryLevelCharacteristic: ServerBleGattCharacteristic
 
     private var lastRequest = DataByteArray()
 
@@ -144,7 +144,7 @@ class GlsServer @Inject constructor(
         OLDEST_RECORD
     )
 
-    val racp = DataByteArray.from(0x06, 0x00, 0x01, 0x01)
+    private val SUCCESS = DataByteArray.from(0x06, 0x00, 0x01, 0x01)
 
     fun start(
         context: Context,
@@ -193,7 +193,8 @@ class GlsServer @Inject constructor(
             context = context,
             config = arrayOf(serviceConfig, batteryService),
             mock = device,
-            logger = { priority, log -> println(log) }
+            scope = scope,
+            logger = { _, log -> println(log) }
         )
 
         val advertiser = BleAdvertiser.create(context)
@@ -224,11 +225,11 @@ class GlsServer @Inject constructor(
         )!!
 
 
-        startGlsService(connection)
-//        startBatteryService(connection)
+        startGlsService()
+//      startBatteryService()
     }
 
-    private fun startGlsService(connection: ServerBluetoothGattConnection) {
+    private fun startGlsService() {
         racpCharacteristic.value
             .onEach { lastRequest = it }
             .launchIn(scope)
@@ -238,42 +239,38 @@ class GlsServer @Inject constructor(
         sendResponse(lastRequest)
     }
 
-    private fun sendResponse(request: DataByteArray) {
-        if (request == RecordAccessControlPointInputParser.reportNumberOfAllStoredRecords()) {
-            sendAll(glsCharacteristic)
-            racpCharacteristic.setValue(racp)
-        } else if (request == RecordAccessControlPointInputParser.reportLastStoredRecord()) {
-            sendLast(glsCharacteristic)
-            racpCharacteristic.setValue(racp)
-        } else if (request == RecordAccessControlPointInputParser.reportFirstStoredRecord()) {
-            sendFirst(glsCharacteristic)
-            racpCharacteristic.setValue(racp)
+    private fun sendResponse(request: DataByteArray) = scope.launch {
+        when (request) {
+            RecordAccessControlPointInputParser.reportNumberOfAllStoredRecords() -> {
+                records.forEach {
+                    send(glsCharacteristic, it)
+                    delay(100)
+                }
+                racpCharacteristic.setValueAndNotifyClient(SUCCESS)
+            }
+            RecordAccessControlPointInputParser.reportLastStoredRecord() -> {
+                send(glsCharacteristic, records.last())
+                send(racpCharacteristic, SUCCESS)
+            }
+            RecordAccessControlPointInputParser.reportFirstStoredRecord() -> {
+                send(glsCharacteristic, records.first())
+                send(racpCharacteristic, SUCCESS)
+            }
         }
     }
 
-    private fun sendFirst(characteristics: ServerBleGattCharacteristic) {
-        characteristics.setValue(records.first())
+    private suspend fun send(characteristics: ServerBleGattCharacteristic, data: DataByteArray) {
+        characteristics.setValueAndNotifyClient(data)
     }
 
-    private fun sendLast(characteristics: ServerBleGattCharacteristic) {
-        characteristics.setValue(records.last())
-    }
-
-    private fun sendAll(characteristics: ServerBleGattCharacteristic) = scope.launch {
-        records.forEach {
-            characteristics.setValue(it)
-            delay(100)
-        }
-    }
-
-    private fun startBatteryService(connection: ServerBluetoothGattConnection) {
+    private fun startBatteryService() {
         scope.launch {
             repeat(100) {
-                batteryLevelCharacteristic.setValue(DataByteArray.from(0x61))
+                send(batteryLevelCharacteristic, DataByteArray.from(0x61))
                 delay(STANDARD_DELAY)
-                batteryLevelCharacteristic.setValue(DataByteArray.from(0x60))
+                send(batteryLevelCharacteristic, DataByteArray.from(0x60))
                 delay(STANDARD_DELAY)
-                batteryLevelCharacteristic.setValue(DataByteArray.from(0x5F))
+                send(batteryLevelCharacteristic, DataByteArray.from(0x5F))
                 delay(STANDARD_DELAY)
             }
         }

--- a/profile_gls/src/main/java/no/nordicsemi/android/gls/GlsServer.kt
+++ b/profile_gls/src/main/java/no/nordicsemi/android/gls/GlsServer.kt
@@ -224,7 +224,6 @@ class GlsServer @Inject constructor(
             BATTERY_LEVEL_CHARACTERISTIC_UUID
         )!!
 
-
         startGlsService()
 //      startBatteryService()
     }

--- a/profile_gls/src/main/java/no/nordicsemi/android/gls/details/view/GLSDetailsContentView.kt
+++ b/profile_gls/src/main/java/no/nordicsemi/android/gls/details/view/GLSDetailsContentView.kt
@@ -40,7 +40,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -71,7 +71,7 @@ internal fun GLSDetailsContentView(record: GLSRecord, context: GLSMeasurementCon
                     )
                 }
 
-                Divider(
+                HorizontalDivider(
                     color = MaterialTheme.colorScheme.secondary,
                     thickness = 1.dp,
                     modifier = Modifier.padding(vertical = 16.dp)
@@ -112,7 +112,7 @@ internal fun GLSDetailsContentView(record: GLSRecord, context: GLSMeasurementCon
                 }
 
                 record.status?.let {
-                    Divider(
+                    HorizontalDivider(
                         color = MaterialTheme.colorScheme.secondary,
                         thickness = 1.dp,
                         modifier = Modifier.padding(vertical = 16.dp)
@@ -178,7 +178,7 @@ internal fun GLSDetailsContentView(record: GLSRecord, context: GLSMeasurementCon
                 }
 
                 context?.let {
-                    Divider(
+                    HorizontalDivider(
                         color = MaterialTheme.colorScheme.secondary,
                         thickness = 1.dp,
                         modifier = Modifier.padding(vertical = 16.dp)

--- a/profile_hrs/build.gradle.kts
+++ b/profile_hrs/build.gradle.kts
@@ -45,23 +45,22 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
+    implementation(libs.nordic.navigation)
+    implementation(libs.nordic.uilogger)
+
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
+    implementation(libs.nordic.blek.uiscanner)
 
     implementation(libs.chart)
 
-    implementation(libs.nordic.theme)
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-    implementation(libs.nordic.navigation)
-    implementation(libs.nordic.blek.uiscanner)
-    implementation(libs.nordic.uilogger)
-    implementation(libs.nordic.core)
-
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_hrs/src/main/java/no/nordicsemi/android/hrs/service/HRSService.kt
+++ b/profile_hrs/src/main/java/no/nordicsemi/android/hrs/service/HRSService.kt
@@ -88,7 +88,7 @@ internal class HRSService : NotificationService() {
     }
 
     private fun startGattClient(device: ServerDevice) = lifecycleScope.launch {
-        val client = ClientBleGatt.connect(this@HRSService, device, logger = { p, s -> repository.log(p, s) })
+        val client = ClientBleGatt.connect(this@HRSService, device, lifecycleScope, logger = { p, s -> repository.log(p, s) })
         this@HRSService.client = client
 
         client.waitForBonding()

--- a/profile_hts/build.gradle.kts
+++ b/profile_hts/build.gradle.kts
@@ -47,20 +47,18 @@ dependencies {
 
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-
-    implementation(libs.nordic.theme)
     implementation(libs.nordic.blek.uiscanner)
+
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.uilogger)
-    implementation(libs.nordic.core)
 
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_hts/src/main/java/no/nordicsemi/android/hts/repository/HTSService.kt
+++ b/profile_hts/src/main/java/no/nordicsemi/android/hts/repository/HTSService.kt
@@ -86,7 +86,7 @@ internal class HTSService : NotificationService() {
     }
 
     private fun startGattClient(device: ServerDevice) = lifecycleScope.launch {
-        val client = ClientBleGatt.connect(this@HTSService, device, logger = { p, s -> repository.log(p, s) })
+        val client = ClientBleGatt.connect(this@HTSService, device, lifecycleScope, logger = { p, s -> repository.log(p, s) })
         this@HTSService.client = client
 
         client.connectionStateWithStatus

--- a/profile_prx/build.gradle.kts
+++ b/profile_prx/build.gradle.kts
@@ -48,20 +48,18 @@ dependencies {
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
     implementation(libs.nordic.blek.server)
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-
-    implementation(libs.nordic.theme)
     implementation(libs.nordic.blek.uiscanner)
+
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.uilogger)
-    implementation(libs.nordic.core)
 
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXService.kt
+++ b/profile_prx/src/main/java/no/nordicsemi/android/prx/repository/PRXService.kt
@@ -129,7 +129,7 @@ internal class PRXService : NotificationService() {
             characteristicConfigs = listOf(linkLossCharacteristic)
         )
 
-        val server = ServerBleGatt.create(this@PRXService, prxServiceConfig, linkLossServiceConfig)
+        val server = ServerBleGatt.create(this@PRXService, lifecycleScope, prxServiceConfig, linkLossServiceConfig)
         this@PRXService.server = server
 
         //Order is important. We don't want to connect before services have been added to the server.
@@ -163,6 +163,7 @@ internal class PRXService : NotificationService() {
         val client = ClientBleGatt.connect(
             this@PRXService,
             device,
+            lifecycleScope,
             logger = { p, s -> repository.log(p, s) },
             options = BleGattConnectOptions(autoConnect = true)
         )

--- a/profile_rscs/build.gradle.kts
+++ b/profile_rscs/build.gradle.kts
@@ -45,22 +45,20 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
-    implementation(libs.nordic.blek.client)
-    implementation(libs.nordic.blek.profile)
-
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-
+    implementation(libs.nordic.core)
     implementation(libs.nordic.theme)
-    implementation(libs.nordic.blek.uiscanner)
     implementation(libs.nordic.navigation)
     implementation(libs.nordic.uilogger)
-    implementation(libs.nordic.core)
 
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.nordic.blek.client)
+    implementation(libs.nordic.blek.profile)
+    implementation(libs.nordic.blek.uiscanner)
+
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 }

--- a/profile_rscs/src/main/java/no/nordicsemi/android/rscs/repository/RSCSService.kt
+++ b/profile_rscs/src/main/java/no/nordicsemi/android/rscs/repository/RSCSService.kt
@@ -86,7 +86,7 @@ internal class RSCSService : NotificationService() {
     }
 
     private fun startGattClient(device: ServerDevice) = lifecycleScope.launch {
-        val client = ClientBleGatt.connect(this@RSCSService, device, logger = { p, s -> repository.log(p, s) })
+        val client = ClientBleGatt.connect(this@RSCSService, device, lifecycleScope, logger = { p, s -> repository.log(p, s) })
         this@RSCSService.client = client
 
         client.connectionStateWithStatus

--- a/profile_uart/build.gradle.kts
+++ b/profile_uart/build.gradle.kts
@@ -50,11 +50,17 @@ dependencies {
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))
 
+    implementation(libs.nordic.core)
+    implementation(libs.nordic.theme)
+    implementation(libs.nordic.navigation)
+    implementation(libs.nordic.uilogger)
+
     implementation(libs.nordic.blek.client)
     implementation(libs.nordic.blek.profile)
     implementation(libs.nordic.blek.core)
     implementation(libs.nordic.blek.server)
     implementation(libs.nordic.blek.advertiser)
+    implementation(libs.nordic.blek.uiscanner)
 
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
@@ -63,24 +69,15 @@ dependencies {
     implementation(libs.accompanist.pager)
     implementation(libs.accompanist.pagerindicators)
 
-    implementation(libs.nordic.ble.common)
-    implementation(libs.nordic.ble.ktx)
-
-    implementation(libs.nordic.theme)
-    implementation(libs.nordic.navigation)
-    implementation(libs.nordic.uilogger)
-    implementation(libs.nordic.core)
-    implementation(libs.nordic.blek.uiscanner)
-
     implementation(libs.androidx.dataStore.core)
     implementation(libs.androidx.dataStore.preferences)
-
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.service)
+
+    implementation(libs.androidx.hilt.navigation.compose)
 
     testImplementation(libs.hilt.android.testing)
     kaptTest(libs.hilt.compiler)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,7 +50,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:1.9.13")
+            from("no.nordicsemi.android.gradle:version-catalog:1.10.6")
         }
     }
 }


### PR DESCRIPTION
This PR migrates to latest dependencies, including BLEK.
* `setValue` changed to `setValueAndNotifyClient`
* Scope added to `connect` methods

Additional clean up:
* Removal of old BLE Library dependencies
* Dependencies reordered