### PR TITLE
UART Presets fixed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     implementation(project(":lib_analytics"))
     implementation(project(":profile-parsers"))
     implementation(project(":profile_manager"))
-    api(project(":profile"))
+    implementation(project(":profile"))
     implementation(project(":profile_data"))
     implementation(project(":lib_ui"))
     implementation(project(":lib_utils"))

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,19 +1,5 @@
-
-# Simple XML
--dontwarn javax.xml.**
-
--keep public class org.simpleframework.**{ *; }
--keep class org.simpleframework.xml.**{ *; }
--keep class org.simpleframework.xml.core.**{ *; }
--keep class org.simpleframework.xml.util.**{ *; }
-
 -keepattributes Signature
 -keepattributes *Annotation*
-
-# Ignore our XML Serialization classes
--keep public class your.annotated.pojo.models.*{
-  public protected private *;
-}
 
 # Crashlytics
 -keepattributes SourceFile,LineNumberTable        # Keep file names and line numbers.

--- a/profile/module-rules.pro
+++ b/profile/module-rules.pro
@@ -1,21 +1,15 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Simple XML
+-dontwarn javax.xml.**
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keep public class org.simpleframework.**{ *; }
+-keep class org.simpleframework.xml.**{ *; }
+-keep class org.simpleframework.xml.core.**{ *; }
+-keep class org.simpleframework.xml.util.**{ *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Ignore our XML Serialization classes
+-keep public class no.nordicsemi.android.toolbox.profile.repository.uartXml.XmlConfiguration {
+  public protected private *;
+}
+-keep public class no.nordicsemi.android.toolbox.profile.repository.uartXml.XmlMacro {
+  public protected private *;
+}


### PR DESCRIPTION
This PR fixes storing Presets in UART profile.

R8 configuration was renaming all fields and classes to shortened values. Also, the default empty constructor in `XmlMacro` and `XmlConfiguration` was being removed, so no instance could have been created.

By moving proguard configuration to the module file we keep better separation, where each module configures its own proguard rules.