### PR TITLE
Fix: safely update the map only if the existing entry is present

### DIFF
--- a/lib_service/src/main/java/no/nordicsemi/android/service/profile/ProfileService.kt
+++ b/lib_service/src/main/java/no/nordicsemi/android/service/profile/ProfileService.kt
@@ -155,12 +155,15 @@ internal class ProfileService : NotificationService() {
                         .createServiceManager(removeService.uuid)
                         ?.also { manager ->
                             foundMatchingService = true
-                            _devices.update {
-                                it + (peripheral.address to it[peripheral.address]!!.copy(
-                                    services = it[peripheral.address]?.services?.plus(
-                                        manager
-                                    ) ?: listOf(manager)
-                                ))
+                            _devices.update { currentMap ->
+                                val existingData = currentMap[peripheral.address]
+                                if (existingData == null) {
+                                    currentMap
+                                } else {
+                                    currentMap + (peripheral.address to existingData.copy(
+                                        services = existingData.services.plus(manager)
+                                    ))
+                                }
                             }
                             // Launch observation for each service.
                             observeService(peripheral, removeService, manager)


### PR DESCRIPTION
This PR fixes the error caused by the non-null assertion operator `!!` on `it[peripheral.address]!!`.

When the `discoverAndObserveServices` function is running, the corresponding device data for peripheral.address has been removed from the `_devices` map, causing `it[peripheral.address]` to return *null*. This error occurs when the device unexpectedly disconnects shortly after connecting.