### PR TITLE
Fixed visual gaps for invalid measurements in Recent Measurement Chart in CS Profile

### DIFF
--- a/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
+++ b/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
@@ -85,8 +85,8 @@ internal fun createLineChartView(
         }
         axisRight.isEnabled = false
 
-        val entries = points.mapIndexed { i, v ->
-            Entry(-i.toFloat(), v)
+        val entries = points.mapIndexedNotNull { i, v ->
+            if (v == 0.0f) null else Entry(-i.toFloat(), v)
         }.reversed()
 
         legend.apply {
@@ -148,15 +148,21 @@ internal fun createLineChartView(
 }
 
 private fun updateData(points: List<Float>, chart: LineChart) {
-    val entries = points.mapIndexed { i, v ->
-        Entry(-i.toFloat(), v)
+    // We map to entries ONLY if the value is not 0.0f
+    // and use -i.toFloat() to maintain the reverse-chronological X-axis logic.
+    val entries = points.mapIndexedNotNull { i, v ->
+        if (v == 0.0f) null else Entry(-i.toFloat(), v)
     }.reversed()
 
     with(chart) {
-
         if (data != null && data.dataSetCount > 0) {
             val set1 = data!!.getDataSetByIndex(0) as LineDataSet
             set1.values = entries
+
+            // This tells the chart NOT to draw a line between the gaps
+            // (Standard behavior for missing entries, but good to be explicit)
+            set1.isVisible = true
+
             set1.notifyDataSetChanged()
             data!!.notifyDataChanged()
             notifyDataSetChanged()
@@ -177,13 +183,19 @@ private fun LineChartView_Preview() {
                 5.0f,
                 3.6f,
                 4.1f,
+                0.0f,
+                0.0f,
+                0.0f,
                 3.9f,
                 4.8f,
                 2.5f,
                 3.3f,
                 4.0f,
                 3.7f,
+                0.0f,
+                0.0f,
                 4.2f,
+                0.0f,
                 3.0f
             )
         )

--- a/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
+++ b/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
@@ -18,7 +18,6 @@ import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
-import com.github.mikephil.charting.interfaces.datasets.ILineDataSet
 import no.nordicsemi.android.common.theme.NordicTheme
 
 private const val X_AXIS_ELEMENTS_COUNT = 40.0f
@@ -39,163 +38,112 @@ internal fun RecentMeasurementChart(previousData: List<Float>) {
     )
 }
 
+/**
+ * Processes raw data into Chart Entries and Segment Colors.
+ * This ensures the logic is identical for both initial load and updates.
+ */
+private fun prepareChartData(points: List<Float>): Triple<List<Entry>, List<Int>, List<Int>> {
+    val entries = points.mapIndexed { i, v -> Entry(-i.toFloat(), v) }.reversed()
+
+    val segmentColors = mutableListOf<Int>()
+    for (i in 0 until points.size - 1) {
+        if (points[i] == 0.0f || points[i + 1] == 0.0f) {
+            segmentColors.add(Color.TRANSPARENT)
+        } else {
+            segmentColors.add(customBlue)
+        }
+    }
+
+    val circleColors = points.map {
+        if (it == 0.0f) Color.TRANSPARENT else customBlue
+    }.reversed()
+
+    return Triple(entries, segmentColors.reversed(), circleColors)
+}
+
 internal fun createLineChartView(
     isDarkTheme: Boolean,
     context: Context,
     points: List<Float>
 ): LineChart {
     return LineChart(context).apply {
+        // 1. General Configuration
         description.isEnabled = false
-
-        legend.isEnabled = true
-
         setTouchEnabled(false)
-
         setDrawGridBackground(false)
-
         isDragEnabled = false
         setScaleEnabled(false)
         setPinchZoom(false)
 
-        if (isDarkTheme) {
-            setBackgroundColor(Color.TRANSPARENT)
-            xAxis.gridColor = Color.WHITE
-            xAxis.textColor = Color.WHITE
-            axisLeft.gridColor = Color.WHITE
-            axisLeft.textColor = Color.WHITE
-        } else {
-            setBackgroundColor(backgroundColor)
-            xAxis.gridColor = Color.BLACK
-            xAxis.textColor = Color.BLACK
-            axisLeft.gridColor = Color.BLACK
-            axisLeft.textColor = Color.BLACK
-        }
+        // 2. Theme Styling
+        val contentColor = if (isDarkTheme) Color.WHITE else Color.BLACK
+        setBackgroundColor(if (isDarkTheme) Color.TRANSPARENT else backgroundColor)
 
         xAxis.apply {
-            xAxis.enableGridDashedLine(10f, 10f, 0f)
-
+            enableGridDashedLine(10f, 10f, 0f)
             axisMinimum = -X_AXIS_ELEMENTS_COUNT
             axisMaximum = 0f
             setAvoidFirstLastClipping(true)
             position = XAxis.XAxisPosition.BOTTOM
-            setDrawLabels(false) // Hide X-axis labels
-            setDrawGridLines(false) // Hide vertical grid lines
+            setDrawLabels(false)
+            setDrawGridLines(false)
+            gridColor = contentColor
+            textColor = contentColor
         }
+
         axisLeft.apply {
             enableGridDashedLine(10f, 10f, 0f)
+            gridColor = contentColor
+            textColor = contentColor
         }
         axisRight.isEnabled = false
 
-        val entries = points.mapIndexed { i, v ->
-            if (v == 0.0f) null else Entry(-i.toFloat(), v)
-        }.reversed()
-
-        // Legends
-        val legendEntry = LegendEntry().apply {
-            label = "Recent Measurements"
-            form = Legend.LegendForm.LINE
-            formColor = customBlue
-            formLineWidth = 2f
-            formSize = 15f
-        }
+        // 3. Custom Legend (Fixed to prevent multiple dashed lines)
         legend.apply {
             isEnabled = true
             textColor = customBlue
-            form = Legend.LegendForm.LINE
             horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
             verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-            orientation = Legend.LegendOrientation.HORIZONTAL
-            setDrawInside(false)
-
-            // Tell the legend to ignore the dataset colors
-            // and use this specific entry instead.
-            setCustom(listOf(legendEntry))
+            setCustom(
+                listOf(
+                LegendEntry().apply {
+                    label = "Recent Measurements"
+                    form = Legend.LegendForm.LINE
+                    formColor = customBlue
+                    formLineWidth = 2f
+                    formSize = 15f
+                }
+            ))
         }
 
-        // create a dataset and give it a type
-        if (data != null && data.dataSetCount > 0) {
-            val set1 = data!!.getDataSetByIndex(0) as LineDataSet
-            set1.values = entries
-            set1.notifyDataSetChanged()
-            data!!.notifyDataChanged()
-            notifyDataSetChanged()
-        } else {
-            val set1 = LineDataSet(entries, legendEntry.label)
-
-            set1.setDrawIcons(false)
-            set1.setDrawValues(false)
-
-            // draw dashed line
-            set1.enableDashedLine(0f, 0f, 0f)
-
-            // blue lines and points
-            set1.color = customBlue
-            set1.setDrawCircles(false)
-
-            // line thickness and point size
-            set1.lineWidth = 3f
-//            set1.circleRadius = 3f
-
-            // draw points as solid circles
-            set1.setDrawCircleHole(false)
-
-            // customize legend entry
-            set1.formLineWidth = 1f
-            set1.formLineWidth = 2f
-            set1.formSize = 15f
-
-            // text size of values
-            set1.valueTextSize = 9f
-
-            // draw selection line as dashed
-//            set1.enableDashedHighlightLine(10f, 5f, 0f)
-
-            val dataSets = ArrayList<ILineDataSet>()
-            dataSets.add(set1) // add the data sets
-
-            // create a data object with the data sets
-            val data = LineData(dataSets)
-
-            // set data
-            setData(data)
+        // 4. Initial Data Binding
+        val (entries, colors) = prepareChartData(points)
+        val set1 = LineDataSet(entries, "Recent Measurements").apply {
+            setDrawIcons(false)
+            setDrawValues(false)
+            setDrawCircles(false)
+            this.colors = colors // Apply segment colors
+            lineWidth = 3f
+            valueTextSize = 9f
         }
+
+        data = LineData(set1)
     }
 }
 
 private fun updateData(points: List<Float>, chart: LineChart) {
-    val entries = points.mapIndexed { i, v ->
-        Entry(-i.toFloat(), v)
-    }.reversed()
+    val (entries, colors) = prepareChartData(points)
 
-    with(chart) {
-        if (data != null && data.dataSetCount > 0) {
-            val set1 = data!!.getDataSetByIndex(0) as LineDataSet
+    chart.data?.let { lineData ->
+        if (lineData.dataSetCount > 0) {
+            val set1 = lineData.getDataSetByIndex(0) as LineDataSet
             set1.values = entries
-
-            // Generate the segment colors
-            val segmentColors = mutableListOf<Int>()
-
-            // We look at the original 'points' list to decide segment colors
-            // A segment exists between points[i] and points[i+1]
-            for (i in 0 until points.size - 1) {
-                val startValue = points[i]
-                val endValue = points[i + 1]
-
-                // If either end of the segment is 0.0f, the line should be invisible
-                if (startValue == 0.0f || endValue == 0.0f) {
-                    segmentColors.add(Color.TRANSPARENT)
-                } else {
-                    segmentColors.add(customBlue)
-                }
-            }
-
-            // Apply colors
-            set1.colors = segmentColors.reversed()
+            set1.colors = colors // Update segments
 
             set1.notifyDataSetChanged()
-            data!!.notifyDataChanged()
-            notifyDataSetChanged()
-            invalidate()
+            lineData.notifyDataChanged()
+            chart.notifyDataSetChanged()
+            chart.invalidate()
         }
     }
 }

--- a/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
+++ b/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
@@ -34,8 +34,12 @@ internal fun RecentMeasurementChart(previousData: List<Float>) {
         modifier = Modifier
             .fillMaxWidth()
             .height(300.dp),
-        factory = { createLineChartView(isSystemInDarkTheme, it, items) },
-        update = { updateData(items, it) }
+        factory = { context ->
+            createLineChartView(isSystemInDarkTheme, context)
+        },
+        update = { chart ->
+            updateData(items, chart)
+        }
     )
 }
 
@@ -44,7 +48,9 @@ internal fun RecentMeasurementChart(previousData: List<Float>) {
  * This ensures the logic is identical for both initial load and updates.
  * @return Pair<LineDataSet, LineDataSet>: one for solid segments, one for dashed bridges.
  */
-private fun prepareTwoDataSets(points: List<Float>): Pair<LineDataSet, LineDataSet> {
+private fun prepareTwoDataSets(points: List<Float>): Pair<LineDataSet, LineDataSet>? {
+    if (points.isEmpty()) return null
+
     val adjustedPoints = mutableListOf<Float>()
     var lastValidValue = points.firstOrNull { it != 0.0f } ?: 0.0f
 
@@ -58,42 +64,42 @@ private fun prepareTwoDataSets(points: List<Float>): Pair<LineDataSet, LineDataS
 
     val entries = adjustedPoints.mapIndexed { i, v -> Entry(-i.toFloat(), v) }.reversed()
 
-    // SOLID BLUE DATASET
-    val solidColors = mutableListOf<Int>()
-    for (i in 0 until points.size - 1) {
-        if (points[i] != 0.0f && points[i + 1] != 0.0f) solidColors.add(customBlue)
-        else solidColors.add(Color.TRANSPARENT)
+    // Helper to build colors and guarantee size matches entries
+    fun getColors(isSolid: Boolean): List<Int> {
+        val colorList = mutableListOf<Int>()
+        for (i in 0 until points.size - 1) {
+            val isMatch = if (isSolid) (points[i] != 0.0f && points[i + 1] != 0.0f)
+            else (points[i] == 0.0f || points[i + 1] == 0.0f)
+            colorList.add(if (isMatch) (if (isSolid) customBlue else signalLostColor) else Color.TRANSPARENT)
+        }
+
+        while (colorList.size < entries.size) {
+            colorList.add(Color.TRANSPARENT)
+        }
+        return colorList.reversed()
     }
 
     val solidSet = LineDataSet(entries, "Valid Data").apply {
         lineWidth = 3f
         setDrawValues(false)
         setDrawCircles(false)
-        colors = solidColors.reversed()
-    }
-
-    // DASHED DATASET
-    val dashedColors = mutableListOf<Int>()
-    for (i in 0 until points.size - 1) {
-        if (points[i] == 0.0f || points[i + 1] == 0.0f) dashedColors.add(signalLostColor)
-        else dashedColors.add(Color.TRANSPARENT)
+        colors = getColors(true)
     }
 
     val dashedSet = LineDataSet(entries, "Gaps").apply {
         lineWidth = 2f
         setDrawValues(false)
         setDrawCircles(false)
-        colors = dashedColors.reversed()
-        enableDashedLine(10f, 10f, 0f) // Only this set is dashed
+        colors = getColors(false)
+        enableDashedLine(10f, 10f, 0f)
     }
 
     return Pair(solidSet, dashedSet)
 }
 
-internal fun createLineChartView(
+private fun createLineChartView(
     isDarkTheme: Boolean,
     context: Context,
-    points: List<Float>
 ): LineChart {
     return LineChart(context).apply {
         // General Setup
@@ -161,37 +167,21 @@ internal fun createLineChartView(
 
             setCustom(listOf(validEntry, dashPart1, dashPart2))
         }
-
-        // Data Processing & Binding
-        val (solidSet, dashedSet) = prepareTwoDataSets(points)
-
-        // Add both sets to LineData.
-        // Make sure to the order: the last one added is drawn on top.
-        data = LineData(dashedSet, solidSet)
     }
 }
 
 private fun updateData(points: List<Float>, chart: LineChart) {
-    val (newSolid, newDashed) = prepareTwoDataSets(points)
+    val result = prepareTwoDataSets(points)
 
-    chart.data?.let { lineData ->
-        // We assume index 0 is dashed and index 1 is solid based on creation order
-        val dashedSet = lineData.getDataSetByIndex(0) as? LineDataSet
-        val solidSet = lineData.getDataSetByIndex(1) as? LineDataSet
-
-        dashedSet?.apply {
-            values = newDashed.values
-            colors = newDashed.colors
-        }
-        solidSet?.apply {
-            values = newSolid.values
-            colors = newSolid.colors
-        }
-
-        lineData.notifyDataChanged()
-        chart.notifyDataSetChanged()
-        chart.invalidate()
+    if (result == null) {
+        chart.data = null // Clears the chart when no data
+    } else {
+        val (newSolid, newDashed) = result
+        chart.data = LineData(newDashed, newSolid)
     }
+
+    chart.notifyDataSetChanged()
+    chart.invalidate()
 }
 
 @Preview(showBackground = true)

--- a/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
+++ b/profile/src/main/java/no/nordicsemi/android/toolbox/profile/view/channelSounding/RecentMeasurementChart.kt
@@ -24,6 +24,7 @@ private const val X_AXIS_ELEMENTS_COUNT = 40.0f
 
 private val customBlue = "#00A9CE".toColorInt()
 private val backgroundColor = "#F5F5F5".toColorInt()
+private val signalLostColor = "#00A9CE".toColorInt()
 
 @Composable
 internal fun RecentMeasurementChart(previousData: List<Float>) {
@@ -41,24 +42,52 @@ internal fun RecentMeasurementChart(previousData: List<Float>) {
 /**
  * Processes raw data into Chart Entries and Segment Colors.
  * This ensures the logic is identical for both initial load and updates.
+ * @return Pair<LineDataSet, LineDataSet>: one for solid segments, one for dashed bridges.
  */
-private fun prepareChartData(points: List<Float>): Triple<List<Entry>, List<Int>, List<Int>> {
-    val entries = points.mapIndexed { i, v -> Entry(-i.toFloat(), v) }.reversed()
+private fun prepareTwoDataSets(points: List<Float>): Pair<LineDataSet, LineDataSet> {
+    val adjustedPoints = mutableListOf<Float>()
+    var lastValidValue = points.firstOrNull { it != 0.0f } ?: 0.0f
 
-    val segmentColors = mutableListOf<Int>()
-    for (i in 0 until points.size - 1) {
-        if (points[i] == 0.0f || points[i + 1] == 0.0f) {
-            segmentColors.add(Color.TRANSPARENT)
-        } else {
-            segmentColors.add(customBlue)
+    points.forEach { value ->
+        if (value == 0.0f) adjustedPoints.add(lastValidValue)
+        else {
+            adjustedPoints.add(value)
+            lastValidValue = value
         }
     }
 
-    val circleColors = points.map {
-        if (it == 0.0f) Color.TRANSPARENT else customBlue
-    }.reversed()
+    val entries = adjustedPoints.mapIndexed { i, v -> Entry(-i.toFloat(), v) }.reversed()
 
-    return Triple(entries, segmentColors.reversed(), circleColors)
+    // SOLID BLUE DATASET
+    val solidColors = mutableListOf<Int>()
+    for (i in 0 until points.size - 1) {
+        if (points[i] != 0.0f && points[i + 1] != 0.0f) solidColors.add(customBlue)
+        else solidColors.add(Color.TRANSPARENT)
+    }
+
+    val solidSet = LineDataSet(entries, "Valid Data").apply {
+        lineWidth = 3f
+        setDrawValues(false)
+        setDrawCircles(false)
+        colors = solidColors.reversed()
+    }
+
+    // DASHED DATASET
+    val dashedColors = mutableListOf<Int>()
+    for (i in 0 until points.size - 1) {
+        if (points[i] == 0.0f || points[i + 1] == 0.0f) dashedColors.add(signalLostColor)
+        else dashedColors.add(Color.TRANSPARENT)
+    }
+
+    val dashedSet = LineDataSet(entries, "Gaps").apply {
+        lineWidth = 2f
+        setDrawValues(false)
+        setDrawCircles(false)
+        colors = dashedColors.reversed()
+        enableDashedLine(10f, 10f, 0f) // Only this set is dashed
+    }
+
+    return Pair(solidSet, dashedSet)
 }
 
 internal fun createLineChartView(
@@ -67,7 +96,7 @@ internal fun createLineChartView(
     points: List<Float>
 ): LineChart {
     return LineChart(context).apply {
-        // 1. General Configuration
+        // General Setup
         description.isEnabled = false
         setTouchEnabled(false)
         setDrawGridBackground(false)
@@ -75,7 +104,7 @@ internal fun createLineChartView(
         setScaleEnabled(false)
         setPinchZoom(false)
 
-        // 2. Theme Styling
+        // Theme Styling
         val contentColor = if (isDarkTheme) Color.WHITE else Color.BLACK
         setBackgroundColor(if (isDarkTheme) Color.TRANSPARENT else backgroundColor)
 
@@ -83,14 +112,11 @@ internal fun createLineChartView(
             enableGridDashedLine(10f, 10f, 0f)
             axisMinimum = -X_AXIS_ELEMENTS_COUNT
             axisMaximum = 0f
-            setAvoidFirstLastClipping(true)
             position = XAxis.XAxisPosition.BOTTOM
             setDrawLabels(false)
             setDrawGridLines(false)
             gridColor = contentColor
-            textColor = contentColor
         }
-
         axisLeft.apply {
             enableGridDashedLine(10f, 10f, 0f)
             gridColor = contentColor
@@ -98,53 +124,73 @@ internal fun createLineChartView(
         }
         axisRight.isEnabled = false
 
-        // 3. Custom Legend (Fixed to prevent multiple dashed lines)
+        // Custom Legend
+        // We manually define one entry so the user doesn't see "Gaps" in the legend.
         legend.apply {
             isEnabled = true
-            textColor = customBlue
+            textColor = contentColor // Matches theme text color
             horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
             verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-            setCustom(
-                listOf(
-                LegendEntry().apply {
-                    label = "Recent Measurements"
-                    form = Legend.LegendForm.LINE
-                    formColor = customBlue
-                    formLineWidth = 2f
-                    formSize = 15f
-                }
-            ))
+            orientation = Legend.LegendOrientation.HORIZONTAL
+            setDrawInside(false)
+            xEntrySpace = 20f // Add some space between the two legend items
+
+            val validEntry = LegendEntry().apply {
+                label = "Recent Measurements"
+                form = Legend.LegendForm.LINE
+                formColor = customBlue
+                formLineWidth = 2f
+                formSize = 15f
+            }
+            // Adding two small segment lines to have the effect of dashed lines.
+            val dashPart1 = LegendEntry().apply {
+                label = null // Leave label null so it sits next to the next part
+                form = Legend.LegendForm.LINE
+                formColor = signalLostColor
+                formLineWidth = 2f
+                formSize = 4f // Small segment
+            }
+
+            val dashPart2 = LegendEntry().apply {
+                label = "No Signal"
+                form = Legend.LegendForm.LINE
+                formColor = signalLostColor
+                formLineWidth = 2f
+                formSize = 4f // Small segment
+            }
+
+            setCustom(listOf(validEntry, dashPart1, dashPart2))
         }
 
-        // 4. Initial Data Binding
-        val (entries, colors) = prepareChartData(points)
-        val set1 = LineDataSet(entries, "Recent Measurements").apply {
-            setDrawIcons(false)
-            setDrawValues(false)
-            setDrawCircles(false)
-            this.colors = colors // Apply segment colors
-            lineWidth = 3f
-            valueTextSize = 9f
-        }
+        // Data Processing & Binding
+        val (solidSet, dashedSet) = prepareTwoDataSets(points)
 
-        data = LineData(set1)
+        // Add both sets to LineData.
+        // Make sure to the order: the last one added is drawn on top.
+        data = LineData(dashedSet, solidSet)
     }
 }
 
 private fun updateData(points: List<Float>, chart: LineChart) {
-    val (entries, colors) = prepareChartData(points)
+    val (newSolid, newDashed) = prepareTwoDataSets(points)
 
     chart.data?.let { lineData ->
-        if (lineData.dataSetCount > 0) {
-            val set1 = lineData.getDataSetByIndex(0) as LineDataSet
-            set1.values = entries
-            set1.colors = colors // Update segments
+        // We assume index 0 is dashed and index 1 is solid based on creation order
+        val dashedSet = lineData.getDataSetByIndex(0) as? LineDataSet
+        val solidSet = lineData.getDataSetByIndex(1) as? LineDataSet
 
-            set1.notifyDataSetChanged()
-            lineData.notifyDataChanged()
-            chart.notifyDataSetChanged()
-            chart.invalidate()
+        dashedSet?.apply {
+            values = newDashed.values
+            colors = newDashed.colors
         }
+        solidSet?.apply {
+            values = newSolid.values
+            colors = newSolid.colors
+        }
+
+        lineData.notifyDataChanged()
+        chart.notifyDataSetChanged()
+        chart.invalidate()
     }
 }
 


### PR DESCRIPTION
This PR addresses feedback regarding the display of the invalid data in the previous measurement chart in the Channel Sounding profile. Previously, when a measurement failed or returned 0.0f, the graph would draw a steep line down to the zero mark, which inaccurately suggested a valid measurement of zero.